### PR TITLE
BriefingTab: Fix #338

### DIFF
--- a/src/app/app-common/Tab/include/OpenKneeboard/DCSBriefingTab.h
+++ b/src/app/app-common/Tab/include/OpenKneeboard/DCSBriefingTab.h
@@ -64,6 +64,10 @@ class DCSBriefingTab final : public TabBase,
   std::shared_ptr<ImageFilePageSource> mImagePages;
   std::shared_ptr<PlainTextPageSource> mTextPages;
   std::filesystem::path mInstallationPath;
+  std::string MissionTextLookup(
+    const LuaRef& mission,
+    const LuaRef& dictionary,
+    const char* key);
 
   struct LatLong {
     DCSWorld::GeoReal mLat;


### PR DESCRIPTION
BriefingTab: Lookup text from dictionary only if key in mission starts with DictKey_

Fix OpenKneeboard/OpenKneeboard#338