### PR TITLE
Encountered error C1083: Cannot open include file: 'winrt/Microsoft.U…

### DIFF
--- a/src/app/app-common/PageSource/PDFFilePageSource.cpp
+++ b/src/app/app-common/PageSource/PDFFilePageSource.cpp
@@ -38,7 +38,8 @@
 
 #include <shims/winrt/base.h>
 
-#include <winrt/Microsoft.UI.Dispatching.h>
+#include <winrt/Windows.UI.Core.h>
+#include <winrt/Windows.System.h>
 #include <winrt/Windows.Data.Pdf.h>
 #include <winrt/Windows.Foundation.h>
 #include <winrt/Windows.Storage.h>
@@ -124,8 +125,8 @@ PDFFilePageSource::~PDFFilePageSource() {
       threadGuard.CheckThread();
       // WIL::resume_foreground guarantees that we will be rescheduled, even
       // though we're not changing threads.
-      co_await wil::resume_foreground(winrt::Microsoft::UI::Dispatching::
-                                        DispatcherQueue::GetForCurrentThread());
+      co_await wil::resume_foreground(
+        winrt::Windows::System::DispatcherQueue::GetForCurrentThread());
     }(mThreadGuard, std::move(p->mPDFDocument));
   }
 }


### PR DESCRIPTION
In PDFFilePageSource.cpp I encountered error C1083: Cannot open include file: 'winrt/Microsoft.UI.Dispatching.h': No such file or directory

Apparently:
When updating (winrt) from 0.8.0 preview to 0.8.0 there was a namespace change from Microsoft.System to Microsoft.UI.Dispatching and resume_foreground is now defined in Microsoft.UI.Dispatching.co_await.h.

Note that accepting this pull request may require winrt to be upgraded.