### PR TITLE
Support changing font size for plain text pages

### DIFF
--- a/src/app/app-common/KneeboardState.cpp
+++ b/src/app/app-common/KneeboardState.cpp
@@ -633,6 +633,13 @@ void KneeboardState::SetDoodlesSettings(const DoodleSettings& value) {
   this->SaveSettings();
 }
 
+void KneeboardState::SetTextSettings(const TextSettings& value) {
+  const EventDelay delay;// lock must be released first
+  const std::unique_lock lock(*this);
+  mSettings.mText = value;
+  this->SaveSettings();
+}
+
 void KneeboardState::StartOpenVRThread() {
   mOpenVRThread = std::jthread([](std::stop_token stopToken) {
     SetThreadDescription(GetCurrentThread(), L"OpenVR Thread");

--- a/src/app/app-common/PageSource/PlainTextFilePageSource.cpp
+++ b/src/app/app-common/PageSource/PlainTextFilePageSource.cpp
@@ -35,7 +35,10 @@ PlainTextFilePageSource::PlainTextFilePageSource(
   const DXResources& dxr,
   KneeboardState* kbs)
   : PageSourceWithDelegates(dxr, kbs),
-    mPageSource(std::make_shared<PlainTextPageSource>(dxr, _("[empty file]"))) {
+    mPageSource(std::make_shared<PlainTextPageSource>(
+      dxr,
+      kbs->GetTextSettings().mFontSize,
+      _("[empty file]"))) {
   this->SetDelegates({std::static_pointer_cast<IPageSource>(mPageSource)});
 }
 

--- a/src/app/app-common/PageSource/PlainTextFilePageSource.cpp
+++ b/src/app/app-common/PageSource/PlainTextFilePageSource.cpp
@@ -35,10 +35,8 @@ PlainTextFilePageSource::PlainTextFilePageSource(
   const DXResources& dxr,
   KneeboardState* kbs)
   : PageSourceWithDelegates(dxr, kbs),
-    mPageSource(std::make_shared<PlainTextPageSource>(
-      dxr,
-      kbs->GetTextSettings().mFontSize,
-      _("[empty file]"))) {
+    mPageSource(
+      std::make_shared<PlainTextPageSource>(dxr, kbs, _("[empty file]"))) {
   this->SetDelegates({std::static_pointer_cast<IPageSource>(mPageSource)});
 }
 

--- a/src/app/app-common/PageSource/PlainTextPageSource.cpp
+++ b/src/app/app-common/PageSource/PlainTextPageSource.cpp
@@ -36,6 +36,7 @@ namespace OpenKneeboard {
 
 PlainTextPageSource::PlainTextPageSource(
   const DXResources& dxr,
+  uint32_t fontSize,
   std::string_view placeholderText)
   : mDXR(dxr), mPlaceholderText(placeholderText) {
   auto dwf = mDXR.mDWriteFactory;
@@ -45,7 +46,7 @@ PlainTextPageSource::PlainTextPageSource(
     DWRITE_FONT_WEIGHT_NORMAL,
     DWRITE_FONT_STYLE_NORMAL,
     DWRITE_FONT_STRETCH_NORMAL,
-    20.0f * RENDER_SCALE,
+    fontSize * RENDER_SCALE,
     L"",
     mTextFormat.put());
 

--- a/src/app/app-common/PageSource/include/OpenKneeboard/PageSourceWithDelegates.h
+++ b/src/app/app-common/PageSource/include/OpenKneeboard/PageSourceWithDelegates.h
@@ -24,6 +24,7 @@
 #include <OpenKneeboard/IPageSource.h>
 #include <OpenKneeboard/IPageSourceWithCursorEvents.h>
 #include <OpenKneeboard/IPageSourceWithNavigation.h>
+#include <OpenKneeboard/KneeboardState.h>
 
 #include <memory>
 #include <tuple>
@@ -35,7 +36,6 @@ namespace OpenKneeboard {
 struct DXResources;
 class CachedLayer;
 class DoodleRenderer;
-class KneeboardState;
 
 class PageSourceWithDelegates : public virtual IPageSource,
                                 public virtual IPageSourceWithCursorEvents,

--- a/src/app/app-common/PageSource/include/OpenKneeboard/PlainTextPageSource.h
+++ b/src/app/app-common/PageSource/include/OpenKneeboard/PlainTextPageSource.h
@@ -20,8 +20,10 @@
 #pragma once
 
 #include "IPageSource.h"
+#include "OpenKneeboard/Events.h"
 
 #include <OpenKneeboard/DXResources.h>
+#include <OpenKneeboard/KneeboardState.h>
 
 #include <OpenKneeboard/utf8.h>
 
@@ -34,15 +36,16 @@ namespace OpenKneeboard {
 
 struct DXResources;
 
-class PlainTextPageSource final : public IPageSource {
+class PlainTextPageSource final : public IPageSource,
+                                  public virtual EventReceiver {
  public:
   PlainTextPageSource() = delete;
   PlainTextPageSource(
     const DXResources&,
-    uint32_t fontSize,
+    KneeboardState* kbs,
     std::string_view placeholderText);
   virtual ~PlainTextPageSource();
-  void ChangeFontSize(uint32_t newFontSize);
+  void OnSettingsChanged();
   bool IsEmpty() const;
   void ClearText();
   void SetText(std::string_view text);
@@ -68,7 +71,7 @@ class PlainTextPageSource final : public IPageSource {
   mutable std::vector<PageID> mPageIDs;
   std::vector<std::vector<winrt::hstring>> mCompletePages;
   std::vector<winrt::hstring> mCurrentPageLines;
-  std::vector<std::string> mMessages;
+  std::vector<std::string> mMessagesToLayout;
   std::vector<std::string> mAllMessages;
 
   std::optional<PageIndex> FindPageIndex(PageID) const;
@@ -80,6 +83,7 @@ class PlainTextPageSource final : public IPageSource {
   uint32_t mFontSize;
 
   DXResources mDXR;
+  KneeboardState* mKneeboard;
   winrt::com_ptr<IDWriteTextFormat> mTextFormat;
   std::string mPlaceholderText;
 

--- a/src/app/app-common/PageSource/include/OpenKneeboard/PlainTextPageSource.h
+++ b/src/app/app-common/PageSource/include/OpenKneeboard/PlainTextPageSource.h
@@ -80,7 +80,7 @@ class PlainTextPageSource final : public IPageSource,
   float mRowHeight = -1.0f;
   int mColumns = -1;
   int mRows = -1;
-  uint32_t mFontSize;
+  float mFontSize;
 
   DXResources mDXR;
   KneeboardState* mKneeboard;

--- a/src/app/app-common/PageSource/include/OpenKneeboard/PlainTextPageSource.h
+++ b/src/app/app-common/PageSource/include/OpenKneeboard/PlainTextPageSource.h
@@ -71,7 +71,7 @@ class PlainTextPageSource final : public IPageSource,
   mutable std::vector<PageID> mPageIDs;
   std::vector<std::vector<winrt::hstring>> mCompletePages;
   std::vector<winrt::hstring> mCurrentPageLines;
-  std::vector<std::string> mMessagesToLayout;
+  std::vector<std::string_view> mMessagesToLayout;
   std::vector<std::string> mAllMessages;
 
   std::optional<PageIndex> FindPageIndex(PageID) const;

--- a/src/app/app-common/PageSource/include/OpenKneeboard/PlainTextPageSource.h
+++ b/src/app/app-common/PageSource/include/OpenKneeboard/PlainTextPageSource.h
@@ -37,7 +37,10 @@ struct DXResources;
 class PlainTextPageSource final : public IPageSource {
  public:
   PlainTextPageSource() = delete;
-  PlainTextPageSource(const DXResources&, std::string_view placeholderText);
+  PlainTextPageSource(
+    const DXResources&,
+    uint32_t fontSize,
+    std::string_view placeholderText);
   virtual ~PlainTextPageSource();
 
   bool IsEmpty() const;

--- a/src/app/app-common/PageSource/include/OpenKneeboard/PlainTextPageSource.h
+++ b/src/app/app-common/PageSource/include/OpenKneeboard/PlainTextPageSource.h
@@ -42,7 +42,7 @@ class PlainTextPageSource final : public IPageSource {
     uint32_t fontSize,
     std::string_view placeholderText);
   virtual ~PlainTextPageSource();
-
+  void ChangeFontSize(uint32_t newFontSize);
   bool IsEmpty() const;
   void ClearText();
   void SetText(std::string_view text);
@@ -69,6 +69,7 @@ class PlainTextPageSource final : public IPageSource {
   std::vector<std::vector<winrt::hstring>> mCompletePages;
   std::vector<winrt::hstring> mCurrentPageLines;
   std::vector<std::string> mMessages;
+  std::vector<std::string> mAllMessages;
 
   std::optional<PageIndex> FindPageIndex(PageID) const;
 
@@ -76,11 +77,13 @@ class PlainTextPageSource final : public IPageSource {
   float mRowHeight = -1.0f;
   int mColumns = -1;
   int mRows = -1;
+  uint32_t mFontSize;
 
   DXResources mDXR;
   winrt::com_ptr<IDWriteTextFormat> mTextFormat;
   std::string mPlaceholderText;
 
+  void UpdateLayoutLimits();
   void LayoutMessages();
   void PushPage();
 };

--- a/src/app/app-common/Settings.cpp
+++ b/src/app/app-common/Settings.cpp
@@ -183,6 +183,7 @@ OPENKNEEBOARD_DEFINE_SPARSE_JSON(
   mApp,
   mDirectInput,
   mDoodles,
+  mText,
   mNonVR,
   mTabletInput,
   mVR)

--- a/src/app/app-common/Tab/DCSBriefingTab.cpp
+++ b/src/app/app-common/Tab/DCSBriefingTab.cpp
@@ -46,6 +46,7 @@ DCSBriefingTab::DCSBriefingTab(
   : TabBase(persistentID, title),
     DCSTab(kbs),
     PageSourceWithDelegates(dxr, kbs),
+    mKneeboard(kbs),
     mImagePages(ImageFilePageSource::Create(dxr)),
     mTextPages(std::make_unique<PlainTextPageSource>(
       dxr,
@@ -55,10 +56,17 @@ DCSBriefingTab::DCSBriefingTab(
     std::static_pointer_cast<IPageSource>(mTextPages),
     std::static_pointer_cast<IPageSource>(mImagePages),
   });
+  AddEventListener(
+    kbs->evSettingsChangedEvent,
+    std::bind_front(&DCSBriefingTab::OnSettingsChanged, this));
 }
 
 DCSBriefingTab::~DCSBriefingTab() {
   this->RemoveAllEventListeners();
+}
+
+void DCSBriefingTab::OnSettingsChanged() {
+  mTextPages->ChangeFontSize(mKneeboard->GetTextSettings().mFontSize);
 }
 
 std::string DCSBriefingTab::GetGlyph() const {

--- a/src/app/app-common/Tab/DCSBriefingTab.cpp
+++ b/src/app/app-common/Tab/DCSBriefingTab.cpp
@@ -48,25 +48,16 @@ DCSBriefingTab::DCSBriefingTab(
     PageSourceWithDelegates(dxr, kbs),
     mKneeboard(kbs),
     mImagePages(ImageFilePageSource::Create(dxr)),
-    mTextPages(std::make_unique<PlainTextPageSource>(
-      dxr,
-      kbs->GetTextSettings().mFontSize,
-      _("[no briefing]"))) {
+    mTextPages(
+      std::make_unique<PlainTextPageSource>(dxr, kbs, _("[no briefing]"))) {
   this->SetDelegates({
     std::static_pointer_cast<IPageSource>(mTextPages),
     std::static_pointer_cast<IPageSource>(mImagePages),
   });
-  AddEventListener(
-    kbs->evSettingsChangedEvent,
-    std::bind_front(&DCSBriefingTab::OnSettingsChanged, this));
 }
 
 DCSBriefingTab::~DCSBriefingTab() {
   this->RemoveAllEventListeners();
-}
-
-void DCSBriefingTab::OnSettingsChanged() {
-  mTextPages->ChangeFontSize(mKneeboard->GetTextSettings().mFontSize);
 }
 
 std::string DCSBriefingTab::GetGlyph() const {

--- a/src/app/app-common/Tab/DCSBriefingTab.cpp
+++ b/src/app/app-common/Tab/DCSBriefingTab.cpp
@@ -47,7 +47,10 @@ DCSBriefingTab::DCSBriefingTab(
     DCSTab(kbs),
     PageSourceWithDelegates(dxr, kbs),
     mImagePages(ImageFilePageSource::Create(dxr)),
-    mTextPages(std::make_unique<PlainTextPageSource>(dxr, _("[no briefing]"))) {
+    mTextPages(std::make_unique<PlainTextPageSource>(
+      dxr,
+      kbs->GetTextSettings().mFontSize,
+      _("[no briefing]"))) {
   this->SetDelegates({
     std::static_pointer_cast<IPageSource>(mTextPages),
     std::static_pointer_cast<IPageSource>(mImagePages),

--- a/src/app/app-common/Tab/DCSRadioLogTab.cpp
+++ b/src/app/app-common/Tab/DCSRadioLogTab.cpp
@@ -51,6 +51,7 @@ DCSRadioLogTab::DCSRadioLogTab(
     PageSourceWithDelegates(dxr, kbs),
     mPageSource(std::make_shared<PlainTextPageSource>(
       dxr,
+      kbs->GetTextSettings().mFontSize,
       _("[waiting for radio messages]"))) {
   this->SetDelegates({mPageSource});
   AddEventListener(mPageSource->evPageAppendedEvent, this->evPageAppendedEvent);

--- a/src/app/app-common/Tab/DCSRadioLogTab.cpp
+++ b/src/app/app-common/Tab/DCSRadioLogTab.cpp
@@ -51,7 +51,7 @@ DCSRadioLogTab::DCSRadioLogTab(
     PageSourceWithDelegates(dxr, kbs),
     mPageSource(std::make_shared<PlainTextPageSource>(
       dxr,
-      kbs->GetTextSettings().mFontSize,
+      kbs,
       _("[waiting for radio messages]"))) {
   this->SetDelegates({mPageSource});
   AddEventListener(mPageSource->evPageAppendedEvent, this->evPageAppendedEvent);

--- a/src/app/app-common/Tab/include/OpenKneeboard/DCSBriefingTab.h
+++ b/src/app/app-common/Tab/include/OpenKneeboard/DCSBriefingTab.h
@@ -81,6 +81,7 @@ class DCSBriefingTab final : public TabBase,
     auto operator<=>(const DCSState&) const = default;
   };
   DCSState mDCSState;
+  KneeboardState* mKneeboard;
 
   constexpr const char* CoalitionKey(
     const char* neutralKey,
@@ -124,6 +125,8 @@ class DCSBriefingTab final : public TabBase,
   void PushMissionObjective(const LuaRef& mission, const LuaRef& dictionary);
   void PushMissionWeather(const LuaRef& mission);
   void PushBullseyeData(const LuaRef& mission);
+
+  void OnSettingsChanged();
 };
 
 }// namespace OpenKneeboard

--- a/src/app/app-common/Tab/include/OpenKneeboard/DCSBriefingTab.h
+++ b/src/app/app-common/Tab/include/OpenKneeboard/DCSBriefingTab.h
@@ -125,8 +125,6 @@ class DCSBriefingTab final : public TabBase,
   void PushMissionObjective(const LuaRef& mission, const LuaRef& dictionary);
   void PushMissionWeather(const LuaRef& mission);
   void PushBullseyeData(const LuaRef& mission);
-
-  void OnSettingsChanged();
 };
 
 }// namespace OpenKneeboard

--- a/src/app/app-common/TextSettings.cpp
+++ b/src/app/app-common/TextSettings.cpp
@@ -1,0 +1,8 @@
+#include <OpenKneeboard/TextSettings.h>
+
+#include <OpenKneeboard/json.h>
+
+namespace OpenKneeboard {
+OPENKNEEBOARD_DEFINE_SPARSE_JSON(TextSettings, mFontSize)
+
+}// namespace OpenKneeboard

--- a/src/app/app-common/include/OpenKneeboard/Settings.h
+++ b/src/app/app-common/include/OpenKneeboard/Settings.h
@@ -24,6 +24,7 @@
 #include <OpenKneeboard/DoodleSettings.h>
 #include <OpenKneeboard/FlatConfig.h>
 #include <OpenKneeboard/TabletSettings.h>
+#include <OpenKneeboard/TextSettings.h>
 #include <OpenKneeboard/VRConfig.h>
 
 #include <shims/filesystem>
@@ -34,6 +35,7 @@ namespace OpenKneeboard {
   IT(AppSettings, App) \
   IT(DirectInputSettings, DirectInput) \
   IT(DoodleSettings, Doodles) \
+  IT(TextSettings, Text) \
   IT(nlohmann::json, Games) \
   IT(FlatConfig, NonVR) \
   IT(TabletSettings, TabletInput) \

--- a/src/app/app-common/include/OpenKneeboard/TextSettings.h
+++ b/src/app/app-common/include/OpenKneeboard/TextSettings.h
@@ -23,7 +23,7 @@
 
 namespace OpenKneeboard {
 struct TextSettings final {
-  uint32_t mFontSize = 12;
+  float mFontSize = 12.f;
 
   constexpr auto operator<=>(const TextSettings&) const = default;
 };

--- a/src/app/app-common/include/OpenKneeboard/TextSettings.h
+++ b/src/app/app-common/include/OpenKneeboard/TextSettings.h
@@ -23,7 +23,7 @@
 
 namespace OpenKneeboard {
 struct TextSettings final {
-  float mFontSize = 12.f;
+  float mFontSize = 20.f;
 
   constexpr auto operator<=>(const TextSettings&) const = default;
 };

--- a/src/app/app-common/include/OpenKneeboard/TextSettings.h
+++ b/src/app/app-common/include/OpenKneeboard/TextSettings.h
@@ -19,39 +19,15 @@
  */
 #pragma once
 
-#include <OpenKneeboard/DCSWorld.h>
-#include <OpenKneeboard/Events.h>
-#include <OpenKneeboard/ITab.h>
-#include <OpenKneeboard/KneeboardState.h>
-
-#include <shims/filesystem>
+#include <OpenKneeboard/json_fwd.h>
 
 namespace OpenKneeboard {
+struct TextSettings final {
+  uint32_t mFontSize = 12;
 
-struct GameEvent;
-
-class DCSTab : public virtual ITab, public virtual EventReceiver {
- public:
-  DCSTab(KneeboardState*);
-  virtual ~DCSTab();
-
-  DCSTab() = delete;
-
- protected:
-  virtual void OnGameEvent(
-    const GameEvent&,
-    const std::filesystem::path& installPath,
-    const std::filesystem::path& savedGamesPath)
-    = 0;
-
-  std::filesystem::path ToAbsolutePath(const std::filesystem::path&);
-
- private:
-  std::filesystem::path mInstallPath;
-  std::filesystem::path mSavedGamesPath;
-  EventHandlerToken mGameEventToken;
-
-  void OnGameEvent(const GameEvent&);
+  constexpr auto operator<=>(const TextSettings&) const = default;
 };
+
+OPENKNEEBOARD_DECLARE_SPARSE_JSON(TextSettings)
 
 }// namespace OpenKneeboard

--- a/src/app/app-winui3/AdvancedSettingsPage.idl
+++ b/src/app/app-winui3/AdvancedSettingsPage.idl
@@ -33,6 +33,8 @@ namespace OpenKneeboardApp
 		UInt32 PenSensitivity;
 		UInt32 EraseSensitivity;
 
+        UInt32 TextPageFontSize;
+
         Boolean Quirk_OculusSDK_DiscardDepthInformation;
         Boolean Quirk_Varjo_OpenXR_D3D12_DoubleBuffer;
         Boolean Quirk_OpenXR_AlwaysUpdateSwapchain;

--- a/src/app/app-winui3/AdvancedSettingsPage.idl
+++ b/src/app/app-winui3/AdvancedSettingsPage.idl
@@ -33,7 +33,7 @@ namespace OpenKneeboardApp
 		UInt32 PenSensitivity;
 		UInt32 EraseSensitivity;
 
-        UInt32 TextPageFontSize;
+        Single TextPageFontSize;
 
         Boolean Quirk_OculusSDK_DiscardDepthInformation;
         Boolean Quirk_Varjo_OpenXR_D3D12_DoubleBuffer;

--- a/src/app/app-winui3/AdvancedSettingsPage.xaml
+++ b/src/app/app-winui3/AdvancedSettingsPage.xaml
@@ -242,6 +242,35 @@
 					Minimum="1.0"
 				/>
 			</StackPanel>
+			<Grid ColumnDefinitions="*, Auto">
+				<TextBlock 
+					Grid.Column="0"
+					Text="Text" 
+					Style="{StaticResource SubtitleTextBlockStyle}" 
+				/>
+				<Button
+					Grid.Column="1"
+					Content="Restore defaults"
+					Click="RestoreTextDefaults"
+				/>
+			</Grid>
+			<StackPanel 
+				Background="{ThemeResource CardBackgroundFillColorDefaultBrush}" 
+				BorderBrush="{ThemeResource CardStrokeColorDefaultBrush}" 
+				CornerRadius="4"
+				BorderThickness="1"
+				Padding="8"
+        Spacing="12">
+				<Slider 
+					Header="Font size" 
+					Value="{x:Bind TextPageFontSize}"
+					TickPlacement="Outside" 
+					TickFrequency="5" 
+					StepFrequency="1" 
+					Maximum="30" 
+					Minimum="6"
+				/>
+			</StackPanel>
       <TextBlock
         Text="In-Game Interface"
         Style="{ThemeResource SubtitleTextBlockStyle}"

--- a/src/app/app-winui3/AdvancedSettingsPage.xaml.cpp
+++ b/src/app/app-winui3/AdvancedSettingsPage.xaml.cpp
@@ -245,6 +245,23 @@ void AdvancedSettingsPage::EraseSensitivity(uint32_t value) {
   gKneeboard->SetDoodlesSettings(ds);
 }
 
+uint32_t AdvancedSettingsPage::TextPageFontSize() {
+  return gKneeboard->GetTextSettings().mFontSize;
+}
+
+void AdvancedSettingsPage::TextPageFontSize(uint32_t value) {
+  auto s = gKneeboard->GetTextSettings();
+  s.mFontSize = value;
+  gKneeboard->SetTextSettings(s);
+}
+
+void AdvancedSettingsPage::RestoreTextDefaults(
+  const IInspectable&,
+  const IInspectable&) noexcept {
+  gKneeboard->ResetTextSettings();
+  mPropertyChangedEvent(*this, PropertyChangedEventArgs(L""));
+}
+
 void AdvancedSettingsPage::RestoreDoodleDefaults(
   const IInspectable&,
   const IInspectable&) noexcept {

--- a/src/app/app-winui3/AdvancedSettingsPage.xaml.cpp
+++ b/src/app/app-winui3/AdvancedSettingsPage.xaml.cpp
@@ -245,11 +245,11 @@ void AdvancedSettingsPage::EraseSensitivity(uint32_t value) {
   gKneeboard->SetDoodlesSettings(ds);
 }
 
-uint32_t AdvancedSettingsPage::TextPageFontSize() {
+float AdvancedSettingsPage::TextPageFontSize() {
   return gKneeboard->GetTextSettings().mFontSize;
 }
 
-void AdvancedSettingsPage::TextPageFontSize(uint32_t value) {
+void AdvancedSettingsPage::TextPageFontSize(float value) {
   auto s = gKneeboard->GetTextSettings();
   s.mFontSize = value;
   gKneeboard->SetTextSettings(s);

--- a/src/app/app-winui3/AdvancedSettingsPage.xaml.h
+++ b/src/app/app-winui3/AdvancedSettingsPage.xaml.h
@@ -75,6 +75,7 @@ struct AdvancedSettingsPage
   void InGameFooterFrameCount(bool) noexcept;
 
   void RestoreDoodleDefaults(const IInspectable&, const IInspectable&) noexcept;
+  void RestoreTextDefaults(const IInspectable&, const IInspectable&) noexcept;
   void RestoreQuirkDefaults(const IInspectable&, const IInspectable&) noexcept;
 
   uint32_t MinimumPenRadius();
@@ -86,6 +87,9 @@ struct AdvancedSettingsPage
   void MinimumEraseRadius(uint32_t value);
   uint32_t EraseSensitivity();
   void EraseSensitivity(uint32_t value);
+
+  uint32_t TextPageFontSize();
+  void TextPageFontSize(uint32_t value);
 
   bool TintEnabled();
   void TintEnabled(bool value);

--- a/src/app/app-winui3/AdvancedSettingsPage.xaml.h
+++ b/src/app/app-winui3/AdvancedSettingsPage.xaml.h
@@ -88,8 +88,8 @@ struct AdvancedSettingsPage
   uint32_t EraseSensitivity();
   void EraseSensitivity(uint32_t value);
 
-  uint32_t TextPageFontSize();
-  void TextPageFontSize(uint32_t value);
+  float TextPageFontSize();
+  void TextPageFontSize(float value);
 
   bool TintEnabled();
   void TintEnabled(bool value);


### PR DESCRIPTION
This adds a TextSettings object with currently only font size as a member. Currently will only take affect after a restart.

Todo:
- [x] Default value in TextSettings is used by all PlainTextPageSources
- [x] Add UI elements for TextSettings
- [x] Optional: Detect settings change and redraw text content without restart?
- [x] Add event handler to remainder of Tabs that use PlainTextPageSources

Closes #205 