### PR TITLE
 Added settings to viewer

### DIFF
--- a/src/utilities/CMakeLists.txt
+++ b/src/utilities/CMakeLists.txt
@@ -52,6 +52,7 @@ add_utility_executable(
   OpenKneeboard-Viewer
   WIN32
   viewer.cpp
+  viewer-settings.cpp
   viewer-d3d11.cpp
   viewer-d3d12.cpp
   viewer-vulkan.cpp

--- a/src/utilities/viewer-settings.cpp
+++ b/src/utilities/viewer-settings.cpp
@@ -1,0 +1,82 @@
+/*
+ * OpenKneeboard
+ *
+ * Copyright (C) 2022 Fred Emmott <fred@fredemmott.com>
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; version 2.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301,
+ * USA.
+ */
+#include "viewer-settings.h"
+
+#include <OpenKneeboard/Filesystem.h>
+
+#include <OpenKneeboard/json.h>
+#include <OpenKneeboard/utf8.h>
+
+#include <algorithm>
+#include <format>
+#include <fstream>
+
+namespace OpenKneeboard {
+ViewerSettings ViewerSettings::Load() {
+  ViewerSettings ret;
+
+  const auto path = Filesystem::GetSettingsDirectory() / "Viewer.json";
+  if (std::filesystem::exists(path)) {
+    std::ifstream f(path.c_str());
+    nlohmann::json json;
+    f >> json;
+    // ret = json; // this doesnt actually update ret
+
+    ret.mWindowWidth = json["mWindowWidth"];
+    ret.mWindowHeight = json["mWindowHeight"];
+    ret.mWindowX = json["mWindowX"];
+    ret.mWindowY = json["mWindowY"];
+    ret.mStreamerMode = json["mStreamerMode"];
+    ret.mFillMode = json["mFillMode"];
+  }
+
+  return ret;
+}
+
+void ViewerSettings::Save() {
+  const auto dir = Filesystem::GetSettingsDirectory();
+  if (!std::filesystem::exists(dir)) {
+    std::filesystem::create_directories(dir);
+  }
+  nlohmann::json j;// = *this; // this results in null
+
+  j["mWindowWidth"] = mWindowWidth;
+  j["mWindowHeight"] = mWindowHeight;
+  j["mWindowX"] = mWindowX;
+  j["mWindowY"] = mWindowY;
+  j["mStreamerMode"] = mStreamerMode;
+  j["mFillMode"] = mFillMode;
+
+  std::ofstream f(dir / "Viewer.json");
+  f << std::setw(2) << j << std::endl;
+}
+
+// I'm guessing this is supposed to make the conversion from json to object work
+// but for some reason it's not working, so meh
+// OPENKNEEBOARD_DEFINE_SPARSE_JSON(
+//   ViewerSettings,
+//   mWindowWidth,
+//   mWindowHeight,
+//   mWindowX,
+//   mWindowY,
+//   mStreamerMode,
+//   mFillMode)
+
+}// namespace OpenKneeboard

--- a/src/utilities/viewer-settings.cpp
+++ b/src/utilities/viewer-settings.cpp
@@ -55,11 +55,11 @@ void ViewerSettings::Save() {
 }
 
 NLOHMANN_JSON_SERIALIZE_ENUM(
-  FillMode,
+  ViewerFillMode,
   {
-    {FillMode::Default, "Default"},
-    {FillMode::Checkerboard, "Checkerboard"},
-    {FillMode::ColorKey, "ColorKey"},
+    {ViewerFillMode::Default, "Default"},
+    {ViewerFillMode::Checkerboard, "Checkerboard"},
+    {ViewerFillMode::ColorKey, "ColorKey"},
   })
 
 OPENKNEEBOARD_DEFINE_SPARSE_JSON(

--- a/src/utilities/viewer-settings.cpp
+++ b/src/utilities/viewer-settings.cpp
@@ -37,14 +37,7 @@ ViewerSettings ViewerSettings::Load() {
     std::ifstream f(path.c_str());
     nlohmann::json json;
     f >> json;
-    // ret = json; // this doesnt actually update ret
-
-    ret.mWindowWidth = json["mWindowWidth"];
-    ret.mWindowHeight = json["mWindowHeight"];
-    ret.mWindowX = json["mWindowX"];
-    ret.mWindowY = json["mWindowY"];
-    ret.mStreamerMode = json["mStreamerMode"];
-    ret.mFillMode = json["mFillMode"];
+    ret = json;
   }
 
   return ret;
@@ -55,28 +48,27 @@ void ViewerSettings::Save() {
   if (!std::filesystem::exists(dir)) {
     std::filesystem::create_directories(dir);
   }
-  nlohmann::json j;// = *this; // this results in null
-
-  j["mWindowWidth"] = mWindowWidth;
-  j["mWindowHeight"] = mWindowHeight;
-  j["mWindowX"] = mWindowX;
-  j["mWindowY"] = mWindowY;
-  j["mStreamerMode"] = mStreamerMode;
-  j["mFillMode"] = mFillMode;
+  nlohmann::json j = *this;
 
   std::ofstream f(dir / "Viewer.json");
   f << std::setw(2) << j << std::endl;
 }
 
-// I'm guessing this is supposed to make the conversion from json to object work
-// but for some reason it's not working, so meh
-// OPENKNEEBOARD_DEFINE_SPARSE_JSON(
-//   ViewerSettings,
-//   mWindowWidth,
-//   mWindowHeight,
-//   mWindowX,
-//   mWindowY,
-//   mStreamerMode,
-//   mFillMode)
+NLOHMANN_JSON_SERIALIZE_ENUM(
+  FillMode,
+  {
+    {FillMode::Default, "Default"},
+    {FillMode::Checkerboard, "Checkerboard"},
+    {FillMode::ColorKey, "ColorKey"},
+  })
+
+OPENKNEEBOARD_DEFINE_SPARSE_JSON(
+  ViewerSettings,
+  mWindowWidth,
+  mWindowHeight,
+  mWindowX,
+  mWindowY,
+  mStreamerMode,
+  mFillMode)
 
 }// namespace OpenKneeboard

--- a/src/utilities/viewer-settings.cpp
+++ b/src/utilities/viewer-settings.cpp
@@ -48,7 +48,15 @@ void ViewerSettings::Save() {
   if (!std::filesystem::exists(dir)) {
     std::filesystem::create_directories(dir);
   }
-  nlohmann::json j = *this;
+
+  nlohmann::json j;
+  const auto path = Filesystem::GetSettingsDirectory() / "Viewer.json";
+  if (std::filesystem::exists(path)) {
+    std::ifstream f(path.c_str());
+    f >> j;
+  }
+
+  to_json_with_default(j, ViewerSettings {}, *this);
 
   std::ofstream f(dir / "Viewer.json");
   f << std::setw(2) << j << std::endl;

--- a/src/utilities/viewer-settings.h
+++ b/src/utilities/viewer-settings.h
@@ -1,0 +1,51 @@
+/*
+ * OpenKneeboard
+ *
+ * Copyright (C) 2022 Fred Emmott <fred@fredemmott.com>
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; version 2.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301,
+ * USA.
+ */
+#pragma once
+
+#include <OpenKneeboard/json_fwd.h>
+
+#include <shims/winrt/base.h>
+
+namespace OpenKneeboard {
+
+enum class FillMode {
+  Default,
+  Checkerboard,
+  ColorKey,
+};
+
+struct ViewerSettings final {
+  int mWindowWidth {768 / 2};
+  int mWindowHeight {1024 / 2};
+  int mWindowX {CW_USEDEFAULT};
+  int mWindowY {CW_USEDEFAULT};
+
+  bool mStreamerMode {false};
+  FillMode mFillMode {FillMode::Default};
+
+  static ViewerSettings Load();
+  void Save();
+
+  constexpr auto operator<=>(const ViewerSettings&) const noexcept = default;
+};
+
+OPENKNEEBOARD_DECLARE_SPARSE_JSON(ViewerSettings)
+
+}// namespace OpenKneeboard

--- a/src/utilities/viewer-settings.h
+++ b/src/utilities/viewer-settings.h
@@ -25,7 +25,7 @@
 
 namespace OpenKneeboard {
 
-enum class FillMode {
+enum class ViewerFillMode {
   Default,
   Checkerboard,
   ColorKey,
@@ -38,7 +38,7 @@ struct ViewerSettings final {
   int mWindowY {CW_USEDEFAULT};
 
   bool mStreamerMode {false};
-  FillMode mFillMode {FillMode::Default};
+  ViewerFillMode mFillMode {ViewerFillMode::Default};
 
   static ViewerSettings Load();
   void Save();

--- a/src/utilities/viewer.cpp
+++ b/src/utilities/viewer.cpp
@@ -215,6 +215,20 @@ class TestViewerWindow final : private D3D11Resources {
       .lpszClassName = CLASS_NAME,
     };
     RegisterClass(&wc);
+
+    POINT TOP_LEFT = POINT(mSettings.mWindowX, mSettings.mWindowY);
+    POINT BOTTOM_RIGHT = POINT(
+      TOP_LEFT.x + mSettings.mWindowWidth,
+      TOP_LEFT.y + mSettings.mWindowHeight);
+
+    HMONITOR MONA = MonitorFromPoint(TOP_LEFT, MONITOR_DEFAULTTONULL);
+    HMONITOR MONB = MonitorFromPoint(BOTTOM_RIGHT, MONITOR_DEFAULTTONULL);
+
+    if (MONA == NULL || MONA != MONB) {
+      mSettings.mWindowX = CW_USEDEFAULT;
+      mSettings.mWindowY = CW_USEDEFAULT;
+    }
+
     mHwnd = CreateWindowExW(
       0,
       CLASS_NAME,

--- a/src/utilities/viewer.cpp
+++ b/src/utilities/viewer.cpp
@@ -991,6 +991,19 @@ LRESULT CALLBACK TestViewerWindow::WindowProc(
     case WM_CLOSE:
 
       // TODO: update window size and position in gInstance->mSettings
+      if (!IsIconic(hWnd)) {
+        // write window rect
+        RECT windowRect {};
+        if (GetWindowRect(hWnd, &windowRect)) {
+          gInstance->mSettings.mWindowX = windowRect.left;
+          gInstance->mSettings.mWindowY = windowRect.top;
+
+          gInstance->mSettings.mWindowWidth
+            = windowRect.right - windowRect.left;
+          gInstance->mSettings.mWindowHeight
+            = windowRect.bottom - windowRect.top;
+        }
+      }
 
       gInstance->mSettings.Save();
       PostQuitMessage(0);

--- a/src/utilities/viewer.cpp
+++ b/src/utilities/viewer.cpp
@@ -253,8 +253,6 @@ class TestViewerWindow final : private D3D11Resources {
         (1024 / 2) * dpi / USER_DEFAULT_SCREEN_DPI,
         SWP_NOZORDER | SWP_NOMOVE);
     }
-
-    mSettings.Save();
   }
 
   bool HaveDirect2D() const {
@@ -609,7 +607,6 @@ class TestViewerWindow final : private D3D11Resources {
           (static_cast<std::underlying_type_t<FillMode>>(mSettings.mFillMode)
            + 1)
           % FillModeCount);
-        mSettings.Save();
         this->PaintNow();
         return;
       // Streamer
@@ -621,7 +618,6 @@ class TestViewerWindow final : private D3D11Resources {
         } else if (mSettings.mFillMode == FillMode::ColorKey) {
           mSettings.mFillMode = mStreamerModePreviousFillMode;
         }
-        mSettings.Save();
         this->PaintNow();
         return;
       // VR
@@ -993,6 +989,10 @@ LRESULT CALLBACK TestViewerWindow::WindowProc(
       gInstance->OnKeyUp(wParam);
       return DefWindowProc(hWnd, uMsg, wParam, lParam);
     case WM_CLOSE:
+
+      // TODO: update window size and position in gInstance->mSettings
+
+      gInstance->mSettings.Save();
       PostQuitMessage(0);
       return DefWindowProc(hWnd, uMsg, wParam, lParam);
   }

--- a/src/utilities/viewer.cpp
+++ b/src/utilities/viewer.cpp
@@ -119,7 +119,7 @@ class TestViewerWindow final : private D3D11Resources {
   bool mSetInputFocus = false;
   size_t mRenderCacheKey = 0;
 
-  RECT mWindowRect {};
+  std::optional<RECT> mWindowRect {};
   ViewerSettings mSettings {ViewerSettings::Load()};
 
   struct ShaderDrawInfo {
@@ -1016,13 +1016,14 @@ LRESULT CALLBACK TestViewerWindow::WindowProc(
     }
     case WM_CLOSE:
 
-      gInstance->mSettings.mWindowX = gInstance->mWindowRect.left;
-      gInstance->mSettings.mWindowY = gInstance->mWindowRect.top;
-
-      gInstance->mSettings.mWindowWidth
-        = gInstance->mWindowRect.right - gInstance->mWindowRect.left;
-      gInstance->mSettings.mWindowHeight
-        = gInstance->mWindowRect.bottom - gInstance->mWindowRect.top;
+      if (gInstance->mWindowRect.has_value()) {
+        gInstance->mSettings.mWindowX = gInstance->mWindowRect->left;
+        gInstance->mSettings.mWindowY = gInstance->mWindowRect->top;
+        gInstance->mSettings.mWindowWidth
+          = gInstance->mWindowRect->right - gInstance->mWindowRect->left;
+        gInstance->mSettings.mWindowHeight
+          = gInstance->mWindowRect->bottom - gInstance->mWindowRect->top;
+      }
 
       gInstance->mSettings.Save();
       PostQuitMessage(0);

--- a/src/utilities/viewer.cpp
+++ b/src/utilities/viewer.cpp
@@ -163,16 +163,16 @@ class TestViewerWindow final : private D3D11Resources {
     /* colorStride = */ 20,
   };
 
-  static constexpr auto LastFillMode = FillMode::ColorKey;
+  static constexpr auto LastFillMode = ViewerFillMode::ColorKey;
   static constexpr auto FillModeCount
-    = static_cast<std::underlying_type_t<FillMode>>(LastFillMode) + 1;
+    = static_cast<std::underlying_type_t<ViewerFillMode>>(LastFillMode) + 1;
 
-  FillMode mFillMode {FillMode::Default};
+  ViewerFillMode mFillMode {ViewerFillMode::Default};
 
   bool mShowVR {false};
 
   bool mStreamerMode {false};
-  FillMode mStreamerModePreviousFillMode {FillMode::Default};
+  ViewerFillMode mStreamerModePreviousFillMode {ViewerFillMode::Default};
 
   PixelSize mSwapChainSize;
   winrt::com_ptr<IDXGISwapChain1> mSwapChain;
@@ -618,8 +618,9 @@ class TestViewerWindow final : private D3D11Resources {
       }
       // Fill
       case 'F':
-        mSettings.mFillMode = static_cast<FillMode>(
-          (static_cast<std::underlying_type_t<FillMode>>(mSettings.mFillMode)
+        mSettings.mFillMode = static_cast<ViewerFillMode>(
+          (static_cast<std::underlying_type_t<ViewerFillMode>>(
+             mSettings.mFillMode)
            + 1)
           % FillModeCount);
         this->PaintNow();
@@ -629,8 +630,8 @@ class TestViewerWindow final : private D3D11Resources {
         mSettings.mStreamerMode = !mSettings.mStreamerMode;
         if (mSettings.mStreamerMode) {
           mStreamerModePreviousFillMode = mSettings.mFillMode;
-          mSettings.mFillMode = FillMode::ColorKey;
-        } else if (mSettings.mFillMode == FillMode::ColorKey) {
+          mSettings.mFillMode = ViewerFillMode::ColorKey;
+        } else if (mSettings.mFillMode == ViewerFillMode::ColorKey) {
           mSettings.mFillMode = mStreamerModePreviousFillMode;
         }
         this->PaintNow();
@@ -697,13 +698,13 @@ class TestViewerWindow final : private D3D11Resources {
   void PaintBackground() {
     ShaderFillInfo fill;
     switch (mSettings.mFillMode) {
-      case FillMode::Default:
+      case ViewerFillMode::Default:
         fill = mDefaultFill;
         break;
-      case FillMode::Checkerboard:
+      case ViewerFillMode::Checkerboard:
         fill = mCheckerboardFill;
         break;
-      case FillMode::ColorKey:
+      case ViewerFillMode::ColorKey:
         fill = mColorKeyFill;
         break;
     }

--- a/src/utilities/viewer.cpp
+++ b/src/utilities/viewer.cpp
@@ -119,6 +119,7 @@ class TestViewerWindow final : private D3D11Resources {
   bool mSetInputFocus = false;
   size_t mRenderCacheKey = 0;
 
+  RECT mWindowRect {};
   ViewerSettings mSettings {ViewerSettings::Load()};
 
   struct ShaderDrawInfo {
@@ -988,22 +989,26 @@ LRESULT CALLBACK TestViewerWindow::WindowProc(
     case WM_KEYUP:
       gInstance->OnKeyUp(wParam);
       return DefWindowProc(hWnd, uMsg, wParam, lParam);
-    case WM_CLOSE:
-
-      // TODO: update window size and position in gInstance->mSettings
+    case WM_SIZE:
+      [[fallthrough]];
+    case WM_MOVE: {
       if (!IsIconic(hWnd)) {
-        // write window rect
-        RECT windowRect {};
+        RECT windowRect;
         if (GetWindowRect(hWnd, &windowRect)) {
-          gInstance->mSettings.mWindowX = windowRect.left;
-          gInstance->mSettings.mWindowY = windowRect.top;
-
-          gInstance->mSettings.mWindowWidth
-            = windowRect.right - windowRect.left;
-          gInstance->mSettings.mWindowHeight
-            = windowRect.bottom - windowRect.top;
+          gInstance->mWindowRect = windowRect;
         }
       }
+      return 0;
+    }
+    case WM_CLOSE:
+
+      gInstance->mSettings.mWindowX = gInstance->mWindowRect.left;
+      gInstance->mSettings.mWindowY = gInstance->mWindowRect.top;
+
+      gInstance->mSettings.mWindowWidth
+        = gInstance->mWindowRect.right - gInstance->mWindowRect.left;
+      gInstance->mSettings.mWindowHeight
+        = gInstance->mWindowRect.bottom - gInstance->mWindowRect.top;
 
       gInstance->mSettings.Save();
       PostQuitMessage(0);

--- a/src/utilities/viewer.cpp
+++ b/src/utilities/viewer.cpp
@@ -216,15 +216,16 @@ class TestViewerWindow final : private D3D11Resources {
     };
     RegisterClass(&wc);
 
-    POINT TOP_LEFT = POINT(mSettings.mWindowX, mSettings.mWindowY);
-    POINT BOTTOM_RIGHT = POINT(
-      TOP_LEFT.x + mSettings.mWindowWidth,
-      TOP_LEFT.y + mSettings.mWindowHeight);
+    const POINT topLeft = POINT(mSettings.mWindowX, mSettings.mWindowY);
+    const POINT bottomRight = POINT(
+      topLeft.x + mSettings.mWindowWidth, topLeft.y + mSettings.mWindowHeight);
 
-    HMONITOR MONA = MonitorFromPoint(TOP_LEFT, MONITOR_DEFAULTTONULL);
-    HMONITOR MONB = MonitorFromPoint(BOTTOM_RIGHT, MONITOR_DEFAULTTONULL);
+    const HMONITOR topLeftMonitor
+      = MonitorFromPoint(topLeft, MONITOR_DEFAULTTONULL);
+    const HMONITOR bottomRightMonitor
+      = MonitorFromPoint(bottomRight, MONITOR_DEFAULTTONULL);
 
-    if (MONA == NULL || MONA != MONB) {
+    if (topLeftMonitor == NULL || topLeftMonitor != bottomRightMonitor) {
       mSettings.mWindowX = CW_USEDEFAULT;
       mSettings.mWindowY = CW_USEDEFAULT;
     }

--- a/src/utilities/viewer.h
+++ b/src/utilities/viewer.h
@@ -19,6 +19,8 @@
  */
 #pragma once
 
+#include "viewer-settings.h"
+
 #include <OpenKneeboard/SHM.h>
 
 #include <filesystem>


### PR DESCRIPTION
I use the viewer as a mirror to be captured in OBS, but I keep needing to resize the window to some exact size and enable streamer mode, with this change, the window size, position, fillmode, and streamer mode are written to `Viewer.json` (on close),

For now it only writes fill mode and streamer mode dynamically as I'm not sure yet how to get the current window position and size on close in order to save that too at runtime.