### PR TITLE
Viewer alignment

### DIFF
--- a/src/utilities/viewer-settings.cpp
+++ b/src/utilities/viewer-settings.cpp
@@ -66,14 +66,14 @@ NLOHMANN_JSON_SERIALIZE_ENUM(
   ViewerAlignment,
   {
     {ViewerAlignment::TopLeft, "TopLeft"},
-    {ViewerAlignment::TopLeft, "Top"},
-    {ViewerAlignment::TopLeft, "TopRight"},
-    {ViewerAlignment::TopLeft, "Left"},
-    {ViewerAlignment::TopLeft, "Center"},
-    {ViewerAlignment::TopLeft, "Right"},
-    {ViewerAlignment::TopLeft, "BottomLeft"},
-    {ViewerAlignment::TopLeft, "Bottom"},
-    {ViewerAlignment::TopLeft, "BottomRight"},
+    {ViewerAlignment::Top, "Top"},
+    {ViewerAlignment::TopRight, "TopRight"},
+    {ViewerAlignment::Left, "Left"},
+    {ViewerAlignment::Center, "Center"},
+    {ViewerAlignment::Right, "Right"},
+    {ViewerAlignment::BottomLeft, "BottomLeft"},
+    {ViewerAlignment::Bottom, "Bottom"},
+    {ViewerAlignment::BottomRight, "BottomRight"},
   })
 
 NLOHMANN_JSON_SERIALIZE_ENUM(

--- a/src/utilities/viewer-settings.cpp
+++ b/src/utilities/viewer-settings.cpp
@@ -62,19 +62,9 @@ void ViewerSettings::Save() {
   f << std::setw(2) << j << std::endl;
 }
 
-NLOHMANN_JSON_SERIALIZE_ENUM(
-  ViewerAlignment,
-  {
-    {ViewerAlignment::TopLeft, "TopLeft"},
-    {ViewerAlignment::Top, "Top"},
-    {ViewerAlignment::TopRight, "TopRight"},
-    {ViewerAlignment::Left, "Left"},
-    {ViewerAlignment::Center, "Center"},
-    {ViewerAlignment::Right, "Right"},
-    {ViewerAlignment::BottomLeft, "BottomLeft"},
-    {ViewerAlignment::Bottom, "Bottom"},
-    {ViewerAlignment::BottomRight, "BottomRight"},
-  })
+#define IT(x) {ViewerAlignment::x, #x},
+
+NLOHMANN_JSON_SERIALIZE_ENUM(ViewerAlignment, {OPENKNEEBOARD_VIEWER_ALIGNMENTS})
 
 NLOHMANN_JSON_SERIALIZE_ENUM(
   ViewerFillMode,

--- a/src/utilities/viewer-settings.cpp
+++ b/src/utilities/viewer-settings.cpp
@@ -63,6 +63,20 @@ void ViewerSettings::Save() {
 }
 
 NLOHMANN_JSON_SERIALIZE_ENUM(
+  ViewerAlignment,
+  {
+    {ViewerAlignment::TopLeft, "TopLeft"},
+    {ViewerAlignment::TopLeft, "Top"},
+    {ViewerAlignment::TopLeft, "TopRight"},
+    {ViewerAlignment::TopLeft, "Left"},
+    {ViewerAlignment::TopLeft, "Center"},
+    {ViewerAlignment::TopLeft, "Right"},
+    {ViewerAlignment::TopLeft, "BottomLeft"},
+    {ViewerAlignment::TopLeft, "Bottom"},
+    {ViewerAlignment::TopLeft, "BottomRight"},
+  })
+
+NLOHMANN_JSON_SERIALIZE_ENUM(
   ViewerFillMode,
   {
     {ViewerFillMode::Default, "Default"},
@@ -77,6 +91,7 @@ OPENKNEEBOARD_DEFINE_SPARSE_JSON(
   mWindowX,
   mWindowY,
   mStreamerMode,
-  mFillMode)
+  mFillMode,
+  mAlignment)
 
 }// namespace OpenKneeboard

--- a/src/utilities/viewer-settings.cpp
+++ b/src/utilities/viewer-settings.cpp
@@ -63,8 +63,8 @@ void ViewerSettings::Save() {
 }
 
 #define IT(x) {ViewerAlignment::x, #x},
-
 NLOHMANN_JSON_SERIALIZE_ENUM(ViewerAlignment, {OPENKNEEBOARD_VIEWER_ALIGNMENTS})
+#undef IT
 
 NLOHMANN_JSON_SERIALIZE_ENUM(
   ViewerFillMode,

--- a/src/utilities/viewer-settings.h
+++ b/src/utilities/viewer-settings.h
@@ -31,16 +31,29 @@ enum class ViewerFillMode {
   Transparent,
 };
 
+#define OPENKNEEBOARD_VIEWER_ALIGNMENTS \
+  IT(TopLeft) \
+  IT(Top) \
+  IT(TopRight) \
+  IT(Left) \
+  IT(Center) \
+  IT(Right) \
+  IT(BottomLeft) \
+  IT(Bottom) \
+  IT(BottomRight)
+
+consteval size_t ViewerAlignmentsCount() {
+  size_t count = 0;
+#define IT(x) ++count;
+  OPENKNEEBOARD_VIEWER_ALIGNMENTS;
+#undef IT
+  return count;
+}
+
 enum class ViewerAlignment {
-  TopLeft,
-  Top,
-  TopRight,
-  Left,
-  Center,
-  Right,
-  BottomLeft,
-  Bottom,
-  BottomRight,
+#define IT(x) x,
+  OPENKNEEBOARD_VIEWER_ALIGNMENTS
+#undef IT
 };
 
 struct ViewerSettings final {

--- a/src/utilities/viewer-settings.h
+++ b/src/utilities/viewer-settings.h
@@ -31,6 +31,18 @@ enum class ViewerFillMode {
   Transparent,
 };
 
+enum class ViewerAlignment {
+  TopLeft,
+  Top,
+  TopRight,
+  Left,
+  Center,
+  Right,
+  BottomLeft,
+  Bottom,
+  BottomRight,
+};
+
 struct ViewerSettings final {
   int mWindowWidth {768 / 2};
   int mWindowHeight {1024 / 2};
@@ -39,6 +51,7 @@ struct ViewerSettings final {
 
   bool mStreamerMode {false};
   ViewerFillMode mFillMode {ViewerFillMode::Default};
+  ViewerAlignment mAlignment {ViewerAlignment::Center};
 
   static ViewerSettings Load();
   void Save();

--- a/src/utilities/viewer.cpp
+++ b/src/utilities/viewer.cpp
@@ -658,38 +658,16 @@ class TestViewerWindow final : private D3D11Resources {
         this->PaintNow();
         return;
       // Alignment
-      case 'A':
-        switch (mSettings.mAlignment) {
-          case ViewerAlignment::TopLeft:
-            mSettings.mAlignment = ViewerAlignment::Top;
-            break;
-          case ViewerAlignment::Top:
-            mSettings.mAlignment = ViewerAlignment::TopRight;
-            break;
-          case ViewerAlignment::TopRight:
-            mSettings.mAlignment = ViewerAlignment::Left;
-            break;
-          case ViewerAlignment::Left:
-            mSettings.mAlignment = ViewerAlignment::Center;
-            break;
-          case ViewerAlignment::Center:
-            mSettings.mAlignment = ViewerAlignment::Right;
-            break;
-          case ViewerAlignment::Right:
-            mSettings.mAlignment = ViewerAlignment::BottomLeft;
-            break;
-          case ViewerAlignment::BottomLeft:
-            mSettings.mAlignment = ViewerAlignment::Bottom;
-            break;
-          case ViewerAlignment::Bottom:
-            mSettings.mAlignment = ViewerAlignment::BottomRight;
-            break;
-          case ViewerAlignment::BottomRight:
-            mSettings.mAlignment = ViewerAlignment::TopLeft;
-            break;
-        }
+      case 'A': {
+        auto& align = mSettings.mAlignment;
+
+        align = static_cast<ViewerAlignment>(
+          (static_cast<std::underlying_type_t<ViewerAlignment>>(align) + 1)
+          % (int)ViewerAlignmentsCount());
+
         this->PaintNow();
         return;
+      }
     }
 
     if (vkk >= '1' && vkk <= '9') {
@@ -826,35 +804,12 @@ class TestViewerWindow final : private D3D11Resources {
       text += L"\nNo snapshot.";
     }
 
-    switch (mSettings.mAlignment) {
-      case ViewerAlignment::TopLeft:
-        text += L"\nTopLeft";
-        break;
-      case ViewerAlignment::Top:
-        text += L"\nTop";
-        break;
-      case ViewerAlignment::TopRight:
-        text += L"\nTopRight";
-        break;
-      case ViewerAlignment::Left:
-        text += L"\nLeft";
-        break;
-      case ViewerAlignment::Center:
-        text += L"\nCenter";
-        break;
-      case ViewerAlignment::Right:
-        text += L"\nRight";
-        break;
-      case ViewerAlignment::BottomLeft:
-        text += L"\nBottomLeft";
-        break;
-      case ViewerAlignment::Bottom:
-        text += L"\nBottom";
-        break;
-      case ViewerAlignment::BottomRight:
-        text += L"\nBottomRight";
-        break;
-    }
+#define IT(x) \
+  case ViewerAlignment::x: \
+    text += L"\n" #x; \
+    break;
+    switch (mSettings.mAlignment) { OPENKNEEBOARD_VIEWER_ALIGNMENTS }
+#undef IT
 
     if (mShowVR) {
       text += L"\nVR";

--- a/src/utilities/viewer.cpp
+++ b/src/utilities/viewer.cpp
@@ -921,16 +921,6 @@ class TestViewerWindow final : private D3D11Resources {
     const auto scaley = clientSize.Height<float>() / imageSize.mHeight;
     const auto scale = std::min(scalex, scaley);
 
-    /*
-    const auto renderWidth = static_cast<uint32_t>(imageSize.mWidth * scale);
-    const auto renderHeight = static_cast<uint32_t>(imageSize.mHeight * scale);
-
-    const auto renderLeft = 0;// (clientSize.mWidth - renderWidth) / 2;
-    const auto renderTop = 0;// (clientSize.mHeight - renderHeight) / 2;
-    const PixelRect destRect {
-      {renderLeft, renderTop}, {renderWidth, renderHeight}};
-    */
-
     const PixelRect destRect = GetDestRect(imageSize, scale);
 
     auto ctx = mD3D11ImmediateContext.get();

--- a/src/utilities/viewer.cpp
+++ b/src/utilities/viewer.cpp
@@ -818,6 +818,36 @@ class TestViewerWindow final : private D3D11Resources {
       text += L"\nNo snapshot.";
     }
 
+    switch (mSettings.mAlignment) {
+      case ViewerAlignment::TopLeft:
+        text += L"\nTopLeft";
+        break;
+      case ViewerAlignment::Top:
+        text += L"\nTop";
+        break;
+      case ViewerAlignment::TopRight:
+        text += L"\nTopRight";
+        break;
+      case ViewerAlignment::Left:
+        text += L"\nLeft";
+        break;
+      case ViewerAlignment::Center:
+        text += L"\nCenter";
+        break;
+      case ViewerAlignment::Right:
+        text += L"\nRight";
+        break;
+      case ViewerAlignment::BottomLeft:
+        text += L"\nBottomLeft";
+        break;
+      case ViewerAlignment::Bottom:
+        text += L"\nBottom";
+        break;
+      case ViewerAlignment::BottomRight:
+        text += L"\nBottomRight";
+        break;
+    }
+
     if (mShowVR) {
       text += L"\nVR";
     } else {
@@ -890,13 +920,18 @@ class TestViewerWindow final : private D3D11Resources {
     const auto scalex = clientSize.Width<float>() / imageSize.mWidth;
     const auto scaley = clientSize.Height<float>() / imageSize.mHeight;
     const auto scale = std::min(scalex, scaley);
+
+    /*
     const auto renderWidth = static_cast<uint32_t>(imageSize.mWidth * scale);
     const auto renderHeight = static_cast<uint32_t>(imageSize.mHeight * scale);
 
-    const auto renderLeft = (clientSize.mWidth - renderWidth) / 2;
-    const auto renderTop = (clientSize.mHeight - renderHeight) / 2;
+    const auto renderLeft = 0;// (clientSize.mWidth - renderWidth) / 2;
+    const auto renderTop = 0;// (clientSize.mHeight - renderHeight) / 2;
     const PixelRect destRect {
       {renderLeft, renderTop}, {renderWidth, renderHeight}};
+    */
+
+    const PixelRect destRect = GetDestRect(imageSize, scale);
 
     auto ctx = mD3D11ImmediateContext.get();
 
@@ -932,6 +967,54 @@ class TestViewerWindow final : private D3D11Resources {
       mWindowTexture.get(), 0, 0, 0, 0, mRendererTexture.get(), 0, &box);
 
     mRenderCacheKey = snapshot.GetRenderCacheKey();
+  }
+
+  PixelRect GetDestRect(
+    const OpenKneeboard::Geometry2D::Size<uint32_t> imageSize,
+    const float scale) {
+    const auto clientSize = GetClientSize();
+
+    const auto renderWidth = static_cast<uint32_t>(imageSize.mWidth * scale);
+    const auto renderHeight = static_cast<uint32_t>(imageSize.mHeight * scale);
+
+    unsigned int renderLeft = 0;// (clientSize.mWidth - renderWidth) / 2;
+    unsigned int renderTop = 0;// (clientSize.mHeight - renderHeight) / 2;
+
+    switch (mSettings.mAlignment) {
+      case ViewerAlignment::TopLeft:
+        // Topleft is default
+        break;
+      case ViewerAlignment::Top:
+        renderLeft = (clientSize.mWidth - renderWidth) / 2;
+        break;
+      case ViewerAlignment::TopRight:
+        renderLeft = (clientSize.mWidth - renderWidth);
+        break;
+      case ViewerAlignment::Left:
+        renderTop = (clientSize.mHeight - renderHeight) / 2;
+        break;
+      case ViewerAlignment::Center:
+        renderTop = (clientSize.mHeight - renderHeight) / 2;
+        renderLeft = (clientSize.mWidth - renderWidth) / 2;
+        break;
+      case ViewerAlignment::Right:
+        renderTop = (clientSize.mHeight - renderHeight) / 2;
+        renderLeft = (clientSize.mWidth - renderWidth);
+        break;
+      case ViewerAlignment::BottomLeft:
+        renderTop = (clientSize.mHeight - renderHeight);
+        break;
+      case ViewerAlignment::Bottom:
+        renderTop = (clientSize.mHeight - renderHeight);
+        renderLeft = (clientSize.mWidth - renderWidth) / 2;
+        break;
+      case ViewerAlignment::BottomRight:
+        renderTop = (clientSize.mHeight - renderHeight);
+        renderLeft = (clientSize.mWidth - renderWidth);
+        break;
+    }
+
+    return {{renderLeft, renderTop}, {renderWidth, renderHeight}};
   }
 
   void CreateRenderer() {

--- a/src/utilities/viewer.cpp
+++ b/src/utilities/viewer.cpp
@@ -652,6 +652,39 @@ class TestViewerWindow final : private D3D11Resources {
         mShowVR = !mShowVR;
         this->PaintNow();
         return;
+      // Alignment
+      case 'A':
+        switch (mSettings.mAlignment) {
+          case ViewerAlignment::TopLeft:
+            mSettings.mAlignment = ViewerAlignment::Top;
+            break;
+          case ViewerAlignment::Top:
+            mSettings.mAlignment = ViewerAlignment::TopRight;
+            break;
+          case ViewerAlignment::TopRight:
+            mSettings.mAlignment = ViewerAlignment::Left;
+            break;
+          case ViewerAlignment::Left:
+            mSettings.mAlignment = ViewerAlignment::Center;
+            break;
+          case ViewerAlignment::Center:
+            mSettings.mAlignment = ViewerAlignment::Right;
+            break;
+          case ViewerAlignment::Right:
+            mSettings.mAlignment = ViewerAlignment::BottomLeft;
+            break;
+          case ViewerAlignment::BottomLeft:
+            mSettings.mAlignment = ViewerAlignment::Bottom;
+            break;
+          case ViewerAlignment::Bottom:
+            mSettings.mAlignment = ViewerAlignment::BottomRight;
+            break;
+          case ViewerAlignment::BottomRight:
+            mSettings.mAlignment = ViewerAlignment::TopLeft;
+            break;
+        }
+        this->PaintNow();
+        return;
     }
 
     if (vkk >= '1' && vkk <= '9') {

--- a/src/utilities/viewer.cpp
+++ b/src/utilities/viewer.cpp
@@ -977,8 +977,8 @@ class TestViewerWindow final : private D3D11Resources {
     const auto renderWidth = static_cast<uint32_t>(imageSize.mWidth * scale);
     const auto renderHeight = static_cast<uint32_t>(imageSize.mHeight * scale);
 
-    unsigned int renderLeft = 0;// (clientSize.mWidth - renderWidth) / 2;
-    unsigned int renderTop = 0;// (clientSize.mHeight - renderHeight) / 2;
+    unsigned int renderLeft = 0;
+    unsigned int renderTop = 0;
 
     switch (mSettings.mAlignment) {
       case ViewerAlignment::TopLeft:


### PR DESCRIPTION
`A` cycles different alignments;
* TopLeft
* Top
* TopRight
* Left
* Center
* Right
* BottomLeft
* Bottom
* BottomRight

Thought about maybe only needing 3, topleft, center and bottomright or something, but that's not the case because tabs can have different aspect ratios, making topright for example impossible, hence the need for all 9